### PR TITLE
Fixed referencing arrow/line not displaying on tables with foreign key(s).

### DIFF
--- a/adminer.css
+++ b/adminer.css
@@ -1033,20 +1033,25 @@ a[href="#import"]:hover{
 	background: #2f2b3f;
 	border: none;
 	border-radius: 5px;
+	min-width: 160px;
 	box-shadow: 0 5px 8px rgba(0, 0, 0, 0.11);
-	overflow: hidden;
 }
 #schema .table a {
 	display: inline-block;
 	background: #7962f2;
+	border-top-left-radius: 5px;
+	border-top-right-radius: 5px;
 	color: #fff;
 	padding: 7px;
-	min-width: 141px;
-	width: 100%;
+	min-width: 160px;
+	width: 91.7%;
 	margin-bottom: 3px;
 }
 #schema .table span {
 	margin-left: 10px;
+}
+#schema .references {
+	transform: translateY(18px);
 }
 .char {
     color: #00e676;


### PR DESCRIPTION
Under database schema, the referencing arrow/line not displaying on tables with foreign key(s) has been fixed.

This changes also include table position adjustments in database schema, so that arrows point directly into the foreign key.

Before:
![Screenshot 2024-04-11 000021](https://github.com/Niyko/Hydra-Dark-Theme-for-Adminer/assets/122547859/fe9c970d-e018-485f-95e3-85d2fe976080)

After:
![Screenshot 2024-04-11 222432](https://github.com/Niyko/Hydra-Dark-Theme-for-Adminer/assets/122547859/5d801fcb-17f0-4b02-b193-41be1cf021d7)
